### PR TITLE
Setting django version at == 1.4

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 pil
-Django>=1.4
+Django==1.4
 django-registration
 django-bootstrap-form
 simplejson


### PR DESCRIPTION
Forcing django at version 1.4 because newer versions have circular import issues that cause hell and havoc
